### PR TITLE
ctag support for markdown

### DIFF
--- a/ctags
+++ b/ctags
@@ -2,5 +2,5 @@
 --langmap=pml:.pml
 --regex-pml=/<title>(.*)<\/title>/\1/t,title/
 --regex-pml=/id\="([a-z\.]+)"/\1/a,anchor/
---regex-pml=/#+([^ ]+$|[^{]*)/\1/t,title/
---regex-pml=/{#(.*)}/\1/a,anchor/
+--regex-pml=/^#+([^ ]+$|[^{]*)/\1/t,title/
+--regex-pml=/{#(.*)}\s*$/\1/a,anchor/

--- a/ctags
+++ b/ctags
@@ -2,3 +2,5 @@
 --langmap=pml:.pml
 --regex-pml=/<title>(.*)<\/title>/\1/t,title/
 --regex-pml=/id\="([a-z\.]+)"/\1/a,anchor/
+--regex-pml=/#+([^ ]+$|[^{]*)/\1/t,title/
+--regex-pml=/{#(.*)}/\1/a,anchor/


### PR DESCRIPTION
Markdown can be used in PML (I use it). This adds support for markdown title and anchors. The regex is explicit so titles need to start. This shouldn't cause mis-matching of text content.
